### PR TITLE
test: add core database manager tests

### DIFF
--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerFactoryTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerFactoryTest.java
@@ -1,14 +1,12 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
 package com.GMRP.core.databaseManager;
-
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mockConstruction;
 import com.GMRP.BotConfig;
 public class DatabaseManagerFactoryTest {

--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerFactoryTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerFactoryTest.java
@@ -12,57 +12,54 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mockConstruction;
 import com.GMRP.BotConfig;
 public class DatabaseManagerFactoryTest {
-    @Test
-    void create_shouldReturnSQLiteManagerForSQLiteConfig() throws Exception {
-        BotConfig config = mock(BotConfig.class);
+	@Test
+	void create_shouldReturnSQLiteManagerForSQLiteConfig() throws Exception {
+		BotConfig config = mock(BotConfig.class);
 
-        when(config.getDbType()).thenReturn("sqlite");
+		when(config.getDbType()).thenReturn("sqlite");
 
-        try (MockedStatic<BotConfig> botConfig =
-                     mockStatic(BotConfig.class)) {
+		try (MockedStatic<BotConfig> botConfig = mockStatic(BotConfig.class)) {
 
-            botConfig.when(BotConfig::getInstance)
-                    .thenReturn(config);
+			botConfig.when(BotConfig::getInstance)
+					.thenReturn(config);
 
-            IDatabaseManager manager = DatabaseManagerFactory.create();
+			IDatabaseManager manager = DatabaseManagerFactory.create();
 
-            assertInstanceOf(DatabaseManagerSQLite.class, manager);
-        }
-    }
-    @Test
-    void create_shouldReturnSQLiteManagerForUnknownDatabaseType() throws Exception {
-        BotConfig config = mock(BotConfig.class);
+			assertInstanceOf(DatabaseManagerSQLite.class, manager);
+		}
+	}
+	@Test
+	void create_shouldReturnSQLiteManagerForUnknownDatabaseType() throws Exception {
+		BotConfig config = mock(BotConfig.class);
 
-        when(config.getDbType()).thenReturn("unknown");
+		when(config.getDbType()).thenReturn("unknown");
 
-        try (MockedStatic<BotConfig> botConfig =
-                     mockStatic(BotConfig.class)) {
+		try (MockedStatic<BotConfig> botConfig = mockStatic(BotConfig.class)) {
 
-            botConfig.when(BotConfig::getInstance)
-                    .thenReturn(config);
+			botConfig.when(BotConfig::getInstance)
+					.thenReturn(config);
 
-            IDatabaseManager manager = DatabaseManagerFactory.create();
+			IDatabaseManager manager = DatabaseManagerFactory.create();
 
-            assertInstanceOf(DatabaseManagerSQLite.class, manager);
-        }
-    }
-    @Test
-    void create_shouldReturnOracleManagerForOracleConfig() throws Exception {
-        BotConfig config = mock(BotConfig.class);
+			assertInstanceOf(DatabaseManagerSQLite.class, manager);
+		}
+	}
+	@Test
+	void create_shouldReturnOracleManagerForOracleConfig() throws Exception {
+		BotConfig config = mock(BotConfig.class);
 
-        when(config.getDbType()).thenReturn("oracle");
+		when(config.getDbType()).thenReturn("oracle");
 
-        try (MockedStatic<BotConfig> botConfig =
-                     mockStatic(BotConfig.class);
-             MockedConstruction<DatabaseManagerOracle> oracleConstruction =
-                     mockConstruction(DatabaseManagerOracle.class)) {
+		try (MockedStatic<BotConfig> botConfig = mockStatic(BotConfig.class);
+				MockedConstruction<DatabaseManagerOracle> oracleConstruction = mockConstruction(
+						DatabaseManagerOracle.class)) {
 
-            botConfig.when(BotConfig::getInstance)
-                    .thenReturn(config);
+			botConfig.when(BotConfig::getInstance)
+					.thenReturn(config);
 
-            IDatabaseManager manager = DatabaseManagerFactory.create();
+			IDatabaseManager manager = DatabaseManagerFactory.create();
 
-            assertInstanceOf(DatabaseManagerOracle.class, manager);
-        }
-    }
+			assertInstanceOf(DatabaseManagerOracle.class, manager);
+		}
+	}
 }

--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerFactoryTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerFactoryTest.java
@@ -1,0 +1,68 @@
+package com.GMRP.core.databaseManager;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mockConstruction;
+import com.GMRP.BotConfig;
+public class DatabaseManagerFactoryTest {
+    @Test
+    void create_shouldReturnSQLiteManagerForSQLiteConfig() throws Exception {
+        BotConfig config = mock(BotConfig.class);
+
+        when(config.getDbType()).thenReturn("sqlite");
+
+        try (MockedStatic<BotConfig> botConfig =
+                     mockStatic(BotConfig.class)) {
+
+            botConfig.when(BotConfig::getInstance)
+                    .thenReturn(config);
+
+            IDatabaseManager manager = DatabaseManagerFactory.create();
+
+            assertInstanceOf(DatabaseManagerSQLite.class, manager);
+        }
+    }
+    @Test
+    void create_shouldReturnSQLiteManagerForUnknownDatabaseType() throws Exception {
+        BotConfig config = mock(BotConfig.class);
+
+        when(config.getDbType()).thenReturn("unknown");
+
+        try (MockedStatic<BotConfig> botConfig =
+                     mockStatic(BotConfig.class)) {
+
+            botConfig.when(BotConfig::getInstance)
+                    .thenReturn(config);
+
+            IDatabaseManager manager = DatabaseManagerFactory.create();
+
+            assertInstanceOf(DatabaseManagerSQLite.class, manager);
+        }
+    }
+    @Test
+    void create_shouldReturnOracleManagerForOracleConfig() throws Exception {
+        BotConfig config = mock(BotConfig.class);
+
+        when(config.getDbType()).thenReturn("oracle");
+
+        try (MockedStatic<BotConfig> botConfig =
+                     mockStatic(BotConfig.class);
+             MockedConstruction<DatabaseManagerOracle> oracleConstruction =
+                     mockConstruction(DatabaseManagerOracle.class)) {
+
+            botConfig.when(BotConfig::getInstance)
+                    .thenReturn(config);
+
+            IDatabaseManager manager = DatabaseManagerFactory.create();
+
+            assertInstanceOf(DatabaseManagerOracle.class, manager);
+        }
+    }
+}

--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerOracleTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerOracleTest.java
@@ -1,0 +1,177 @@
+package com.GMRP.core.databaseManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import java.sql.Connection;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import com.GMRP.BotConfig;
+import oracle.ucp.jdbc.PoolDataSource;
+import oracle.ucp.jdbc.PoolDataSourceFactory;
+import static org.mockito.Mockito.verify;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+
+public class DatabaseManagerOracleTest {
+    @Test
+    void getConnection_shouldReturnConnectionFromPool() throws Exception {
+        PoolDataSource pool = mock(PoolDataSource.class);
+        Connection connection = mock(Connection.class);
+        BotConfig config = mock(BotConfig.class);
+
+        when(config.getDbConnectString()).thenReturn("test");
+        when(config.getDbUser()).thenReturn("user");
+        when(config.getDbPassword()).thenReturn("password");
+        when(pool.getConnection()).thenReturn(connection);
+
+        try (MockedStatic<PoolDataSourceFactory> poolFactory =
+                     mockStatic(PoolDataSourceFactory.class);
+             MockedStatic<BotConfig> botConfig =
+                     mockStatic(BotConfig.class)) {
+
+            poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
+                    .thenReturn(pool);
+
+            botConfig.when(BotConfig::getInstance)
+                    .thenReturn(config);
+
+            DatabaseManagerOracle manager = new DatabaseManagerOracle();
+
+            assertSame(connection, manager.getConnection());
+        }
+    }
+
+    @Test
+    void testConnection_shouldReturnTrueWhenQuerySucceeds() throws Exception {
+        PoolDataSource pool = mock(PoolDataSource.class);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        BotConfig config = mock(BotConfig.class);
+
+        when(config.getDbConnectString()).thenReturn("test");
+        when(config.getDbUser()).thenReturn("user");
+        when(config.getDbPassword()).thenReturn("password");
+
+        when(pool.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery("SELECT 1 FROM DUAL")).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+
+        try (MockedStatic<PoolDataSourceFactory> poolFactory =
+                     mockStatic(PoolDataSourceFactory.class);
+             MockedStatic<BotConfig> botConfig =
+                     mockStatic(BotConfig.class)) {
+
+            poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
+                    .thenReturn(pool);
+
+            botConfig.when(BotConfig::getInstance)
+                    .thenReturn(config);
+
+            DatabaseManagerOracle manager = new DatabaseManagerOracle();
+
+            assertTrue(manager.testConnection());
+        }
+    }
+    @Test
+    void testConnection_shouldReturnFalseWhenQueryFails() throws Exception {
+        PoolDataSource pool = mock(PoolDataSource.class);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+        BotConfig config = mock(BotConfig.class);
+
+        when(config.getDbConnectString()).thenReturn("test");
+        when(config.getDbUser()).thenReturn("user");
+        when(config.getDbPassword()).thenReturn("password");
+
+        when(pool.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery("SELECT 1 FROM DUAL"))
+                .thenThrow(new SQLException("Database query failed"));
+
+        try (MockedStatic<PoolDataSourceFactory> poolFactory =
+                     mockStatic(PoolDataSourceFactory.class);
+             MockedStatic<BotConfig> botConfig =
+                     mockStatic(BotConfig.class)) {
+
+            poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
+                    .thenReturn(pool);
+
+            botConfig.when(BotConfig::getInstance)
+                    .thenReturn(config);
+
+            DatabaseManagerOracle manager = new DatabaseManagerOracle();
+
+            assertFalse(manager.testConnection());
+        }
+    }
+    @Test
+    void close_shouldNotThrowWhenPoolNameIsBlank() throws Exception {
+        PoolDataSource pool = mock(PoolDataSource.class);
+        BotConfig config = mock(BotConfig.class);
+
+        when(config.getDbConnectString()).thenReturn("test");
+        when(config.getDbUser()).thenReturn("user");
+        when(config.getDbPassword()).thenReturn("password");
+        when(pool.getConnectionPoolName()).thenReturn("");
+
+        try (MockedStatic<PoolDataSourceFactory> poolFactory =
+                     mockStatic(PoolDataSourceFactory.class);
+             MockedStatic<BotConfig> botConfig =
+                     mockStatic(BotConfig.class)) {
+
+            poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
+                    .thenReturn(pool);
+
+            botConfig.when(BotConfig::getInstance)
+                    .thenReturn(config);
+
+            DatabaseManagerOracle manager = new DatabaseManagerOracle();
+
+            assertDoesNotThrow(manager::close);
+        }
+    }
+    @Test
+    void testConnection_shouldCloseResourcesAfterExecution() throws Exception {
+        PoolDataSource pool = mock(PoolDataSource.class);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        BotConfig config = mock(BotConfig.class);
+
+        when(config.getDbConnectString()).thenReturn("test");
+        when(config.getDbUser()).thenReturn("user");
+        when(config.getDbPassword()).thenReturn("password");
+
+        when(pool.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery("SELECT 1 FROM DUAL"))
+                .thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+
+        try (MockedStatic<PoolDataSourceFactory> poolFactory =
+                     mockStatic(PoolDataSourceFactory.class);
+             MockedStatic<BotConfig> botConfig =
+                     mockStatic(BotConfig.class)) {
+
+            poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
+                    .thenReturn(pool);
+
+            botConfig.when(BotConfig::getInstance)
+                    .thenReturn(config);
+
+            DatabaseManagerOracle manager = new DatabaseManagerOracle();
+
+            assertTrue(manager.testConnection());
+
+            verify(resultSet).close();
+            verify(statement).close();
+            verify(connection).close();
+        }
+    }
+}

--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerOracleTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerOracleTest.java
@@ -15,163 +15,152 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-
 public class DatabaseManagerOracleTest {
-    @Test
-    void getConnection_shouldReturnConnectionFromPool() throws Exception {
-        PoolDataSource pool = mock(PoolDataSource.class);
-        Connection connection = mock(Connection.class);
-        BotConfig config = mock(BotConfig.class);
+	@Test
+	void getConnection_shouldReturnConnectionFromPool() throws Exception {
+		PoolDataSource pool = mock(PoolDataSource.class);
+		Connection connection = mock(Connection.class);
+		BotConfig config = mock(BotConfig.class);
 
-        when(config.getDbConnectString()).thenReturn("test");
-        when(config.getDbUser()).thenReturn("user");
-        when(config.getDbPassword()).thenReturn("password");
-        when(pool.getConnection()).thenReturn(connection);
+		when(config.getDbConnectString()).thenReturn("test");
+		when(config.getDbUser()).thenReturn("user");
+		when(config.getDbPassword()).thenReturn("password");
+		when(pool.getConnection()).thenReturn(connection);
 
-        try (MockedStatic<PoolDataSourceFactory> poolFactory =
-                     mockStatic(PoolDataSourceFactory.class);
-             MockedStatic<BotConfig> botConfig =
-                     mockStatic(BotConfig.class)) {
+		try (MockedStatic<PoolDataSourceFactory> poolFactory = mockStatic(PoolDataSourceFactory.class);
+				MockedStatic<BotConfig> botConfig = mockStatic(BotConfig.class)) {
 
-            poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
-                    .thenReturn(pool);
+			poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
+					.thenReturn(pool);
 
-            botConfig.when(BotConfig::getInstance)
-                    .thenReturn(config);
+			botConfig.when(BotConfig::getInstance)
+					.thenReturn(config);
 
-            DatabaseManagerOracle manager = new DatabaseManagerOracle();
+			DatabaseManagerOracle manager = new DatabaseManagerOracle();
 
-            assertSame(connection, manager.getConnection());
-        }
-    }
+			assertSame(connection, manager.getConnection());
+		}
+	}
 
-    @Test
-    void testConnection_shouldReturnTrueWhenQuerySucceeds() throws Exception {
-        PoolDataSource pool = mock(PoolDataSource.class);
-        Connection connection = mock(Connection.class);
-        Statement statement = mock(Statement.class);
-        ResultSet resultSet = mock(ResultSet.class);
-        BotConfig config = mock(BotConfig.class);
+	@Test
+	void testConnection_shouldReturnTrueWhenQuerySucceeds() throws Exception {
+		PoolDataSource pool = mock(PoolDataSource.class);
+		Connection connection = mock(Connection.class);
+		Statement statement = mock(Statement.class);
+		ResultSet resultSet = mock(ResultSet.class);
+		BotConfig config = mock(BotConfig.class);
 
-        when(config.getDbConnectString()).thenReturn("test");
-        when(config.getDbUser()).thenReturn("user");
-        when(config.getDbPassword()).thenReturn("password");
+		when(config.getDbConnectString()).thenReturn("test");
+		when(config.getDbUser()).thenReturn("user");
+		when(config.getDbPassword()).thenReturn("password");
 
-        when(pool.getConnection()).thenReturn(connection);
-        when(connection.createStatement()).thenReturn(statement);
-        when(statement.executeQuery("SELECT 1 FROM DUAL")).thenReturn(resultSet);
-        when(resultSet.next()).thenReturn(true);
+		when(pool.getConnection()).thenReturn(connection);
+		when(connection.createStatement()).thenReturn(statement);
+		when(statement.executeQuery("SELECT 1 FROM DUAL")).thenReturn(resultSet);
+		when(resultSet.next()).thenReturn(true);
 
-        try (MockedStatic<PoolDataSourceFactory> poolFactory =
-                     mockStatic(PoolDataSourceFactory.class);
-             MockedStatic<BotConfig> botConfig =
-                     mockStatic(BotConfig.class)) {
+		try (MockedStatic<PoolDataSourceFactory> poolFactory = mockStatic(PoolDataSourceFactory.class);
+				MockedStatic<BotConfig> botConfig = mockStatic(BotConfig.class)) {
 
-            poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
-                    .thenReturn(pool);
+			poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
+					.thenReturn(pool);
 
-            botConfig.when(BotConfig::getInstance)
-                    .thenReturn(config);
+			botConfig.when(BotConfig::getInstance)
+					.thenReturn(config);
 
-            DatabaseManagerOracle manager = new DatabaseManagerOracle();
+			DatabaseManagerOracle manager = new DatabaseManagerOracle();
 
-            assertTrue(manager.testConnection());
-        }
-    }
-    @Test
-    void testConnection_shouldReturnFalseWhenQueryFails() throws Exception {
-        PoolDataSource pool = mock(PoolDataSource.class);
-        Connection connection = mock(Connection.class);
-        Statement statement = mock(Statement.class);
-        BotConfig config = mock(BotConfig.class);
+			assertTrue(manager.testConnection());
+		}
+	}
+	@Test
+	void testConnection_shouldReturnFalseWhenQueryFails() throws Exception {
+		PoolDataSource pool = mock(PoolDataSource.class);
+		Connection connection = mock(Connection.class);
+		Statement statement = mock(Statement.class);
+		BotConfig config = mock(BotConfig.class);
 
-        when(config.getDbConnectString()).thenReturn("test");
-        when(config.getDbUser()).thenReturn("user");
-        when(config.getDbPassword()).thenReturn("password");
+		when(config.getDbConnectString()).thenReturn("test");
+		when(config.getDbUser()).thenReturn("user");
+		when(config.getDbPassword()).thenReturn("password");
 
-        when(pool.getConnection()).thenReturn(connection);
-        when(connection.createStatement()).thenReturn(statement);
-        when(statement.executeQuery("SELECT 1 FROM DUAL"))
-                .thenThrow(new SQLException("Database query failed"));
+		when(pool.getConnection()).thenReturn(connection);
+		when(connection.createStatement()).thenReturn(statement);
+		when(statement.executeQuery("SELECT 1 FROM DUAL"))
+				.thenThrow(new SQLException("Database query failed"));
 
-        try (MockedStatic<PoolDataSourceFactory> poolFactory =
-                     mockStatic(PoolDataSourceFactory.class);
-             MockedStatic<BotConfig> botConfig =
-                     mockStatic(BotConfig.class)) {
+		try (MockedStatic<PoolDataSourceFactory> poolFactory = mockStatic(PoolDataSourceFactory.class);
+				MockedStatic<BotConfig> botConfig = mockStatic(BotConfig.class)) {
 
-            poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
-                    .thenReturn(pool);
+			poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
+					.thenReturn(pool);
 
-            botConfig.when(BotConfig::getInstance)
-                    .thenReturn(config);
+			botConfig.when(BotConfig::getInstance)
+					.thenReturn(config);
 
-            DatabaseManagerOracle manager = new DatabaseManagerOracle();
+			DatabaseManagerOracle manager = new DatabaseManagerOracle();
 
-            assertFalse(manager.testConnection());
-        }
-    }
-    @Test
-    void close_shouldNotThrowWhenPoolNameIsBlank() throws Exception {
-        PoolDataSource pool = mock(PoolDataSource.class);
-        BotConfig config = mock(BotConfig.class);
+			assertFalse(manager.testConnection());
+		}
+	}
+	@Test
+	void close_shouldNotThrowWhenPoolNameIsBlank() throws Exception {
+		PoolDataSource pool = mock(PoolDataSource.class);
+		BotConfig config = mock(BotConfig.class);
 
-        when(config.getDbConnectString()).thenReturn("test");
-        when(config.getDbUser()).thenReturn("user");
-        when(config.getDbPassword()).thenReturn("password");
-        when(pool.getConnectionPoolName()).thenReturn("");
+		when(config.getDbConnectString()).thenReturn("test");
+		when(config.getDbUser()).thenReturn("user");
+		when(config.getDbPassword()).thenReturn("password");
+		when(pool.getConnectionPoolName()).thenReturn("");
 
-        try (MockedStatic<PoolDataSourceFactory> poolFactory =
-                     mockStatic(PoolDataSourceFactory.class);
-             MockedStatic<BotConfig> botConfig =
-                     mockStatic(BotConfig.class)) {
+		try (MockedStatic<PoolDataSourceFactory> poolFactory = mockStatic(PoolDataSourceFactory.class);
+				MockedStatic<BotConfig> botConfig = mockStatic(BotConfig.class)) {
 
-            poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
-                    .thenReturn(pool);
+			poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
+					.thenReturn(pool);
 
-            botConfig.when(BotConfig::getInstance)
-                    .thenReturn(config);
+			botConfig.when(BotConfig::getInstance)
+					.thenReturn(config);
 
-            DatabaseManagerOracle manager = new DatabaseManagerOracle();
+			DatabaseManagerOracle manager = new DatabaseManagerOracle();
 
-            assertDoesNotThrow(manager::close);
-        }
-    }
-    @Test
-    void testConnection_shouldCloseResourcesAfterExecution() throws Exception {
-        PoolDataSource pool = mock(PoolDataSource.class);
-        Connection connection = mock(Connection.class);
-        Statement statement = mock(Statement.class);
-        ResultSet resultSet = mock(ResultSet.class);
-        BotConfig config = mock(BotConfig.class);
+			assertDoesNotThrow(manager::close);
+		}
+	}
+	@Test
+	void testConnection_shouldCloseResourcesAfterExecution() throws Exception {
+		PoolDataSource pool = mock(PoolDataSource.class);
+		Connection connection = mock(Connection.class);
+		Statement statement = mock(Statement.class);
+		ResultSet resultSet = mock(ResultSet.class);
+		BotConfig config = mock(BotConfig.class);
 
-        when(config.getDbConnectString()).thenReturn("test");
-        when(config.getDbUser()).thenReturn("user");
-        when(config.getDbPassword()).thenReturn("password");
+		when(config.getDbConnectString()).thenReturn("test");
+		when(config.getDbUser()).thenReturn("user");
+		when(config.getDbPassword()).thenReturn("password");
 
-        when(pool.getConnection()).thenReturn(connection);
-        when(connection.createStatement()).thenReturn(statement);
-        when(statement.executeQuery("SELECT 1 FROM DUAL"))
-                .thenReturn(resultSet);
-        when(resultSet.next()).thenReturn(true);
+		when(pool.getConnection()).thenReturn(connection);
+		when(connection.createStatement()).thenReturn(statement);
+		when(statement.executeQuery("SELECT 1 FROM DUAL"))
+				.thenReturn(resultSet);
+		when(resultSet.next()).thenReturn(true);
 
-        try (MockedStatic<PoolDataSourceFactory> poolFactory =
-                     mockStatic(PoolDataSourceFactory.class);
-             MockedStatic<BotConfig> botConfig =
-                     mockStatic(BotConfig.class)) {
+		try (MockedStatic<PoolDataSourceFactory> poolFactory = mockStatic(PoolDataSourceFactory.class);
+				MockedStatic<BotConfig> botConfig = mockStatic(BotConfig.class)) {
 
-            poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
-                    .thenReturn(pool);
+			poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
+					.thenReturn(pool);
 
-            botConfig.when(BotConfig::getInstance)
-                    .thenReturn(config);
+			botConfig.when(BotConfig::getInstance)
+					.thenReturn(config);
 
-            DatabaseManagerOracle manager = new DatabaseManagerOracle();
+			DatabaseManagerOracle manager = new DatabaseManagerOracle();
 
-            assertTrue(manager.testConnection());
+			assertTrue(manager.testConnection());
 
-            verify(resultSet).close();
-            verify(statement).close();
-            verify(connection).close();
-        }
-    }
+			verify(resultSet).close();
+			verify(statement).close();
+			verify(connection).close();
+		}
+	}
 }

--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerOracleTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerOracleTest.java
@@ -1,5 +1,5 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
 package com.GMRP.core.databaseManager;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;

--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerSQLiteTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerSQLiteTest.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
 package com.GMRP.core.databaseManager;
 import static org.junit.jupiter.api.Assertions.*;
 import java.sql.Connection;

--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerSQLiteTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerSQLiteTest.java
@@ -1,0 +1,51 @@
+package com.GMRP.core.databaseManager;
+import static org.junit.jupiter.api.Assertions.*;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import org.junit.jupiter.api.Test;
+
+public class DatabaseManagerSQLiteTest {
+    @Test
+    void getConnection_shouldReturnValidConnection() throws SQLException {
+        DatabaseManagerSQLite manager =
+                new DatabaseManagerSQLite(":memory:");
+
+        try (Connection connection = manager.getConnection()) {
+            assertNotNull(connection);
+            assertFalse(connection.isClosed());
+        }
+    }
+    @Test
+    void testConnection_shouldReturnTrueForValidDatabase() {
+        DatabaseManagerSQLite manager =
+                new DatabaseManagerSQLite(":memory:");
+
+        assertTrue(manager.testConnection());
+    }
+    @Test
+    void getConnection_shouldAllowSqlExecution() throws SQLException {
+        DatabaseManagerSQLite manager =
+                new DatabaseManagerSQLite(":memory:");
+
+        try (Connection connection = manager.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("SELECT 1")) {
+
+            assertTrue(resultSet.next());
+            assertEquals(1, resultSet.getInt(1));
+        }
+    }
+    @Test
+    void testConnection_shouldReturnFalseWhenConnectionFails() {
+        DatabaseManagerSQLite manager = new DatabaseManagerSQLite(":memory:") {
+            @Override
+            public Connection getConnection() throws SQLException {
+                throw new SQLException("Database connection failed");
+            }
+        };
+
+        assertFalse(manager.testConnection());
+    }
+}

--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerSQLiteTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerSQLiteTest.java
@@ -7,45 +7,42 @@ import java.sql.Statement;
 import org.junit.jupiter.api.Test;
 
 public class DatabaseManagerSQLiteTest {
-    @Test
-    void getConnection_shouldReturnValidConnection() throws SQLException {
-        DatabaseManagerSQLite manager =
-                new DatabaseManagerSQLite(":memory:");
+	@Test
+	void getConnection_shouldReturnValidConnection() throws SQLException {
+		DatabaseManagerSQLite manager = new DatabaseManagerSQLite(":memory:");
 
-        try (Connection connection = manager.getConnection()) {
-            assertNotNull(connection);
-            assertFalse(connection.isClosed());
-        }
-    }
-    @Test
-    void testConnection_shouldReturnTrueForValidDatabase() {
-        DatabaseManagerSQLite manager =
-                new DatabaseManagerSQLite(":memory:");
+		try (Connection connection = manager.getConnection()) {
+			assertNotNull(connection);
+			assertFalse(connection.isClosed());
+		}
+	}
+	@Test
+	void testConnection_shouldReturnTrueForValidDatabase() {
+		DatabaseManagerSQLite manager = new DatabaseManagerSQLite(":memory:");
 
-        assertTrue(manager.testConnection());
-    }
-    @Test
-    void getConnection_shouldAllowSqlExecution() throws SQLException {
-        DatabaseManagerSQLite manager =
-                new DatabaseManagerSQLite(":memory:");
+		assertTrue(manager.testConnection());
+	}
+	@Test
+	void getConnection_shouldAllowSqlExecution() throws SQLException {
+		DatabaseManagerSQLite manager = new DatabaseManagerSQLite(":memory:");
 
-        try (Connection connection = manager.getConnection();
-             Statement statement = connection.createStatement();
-             ResultSet resultSet = statement.executeQuery("SELECT 1")) {
+		try (Connection connection = manager.getConnection();
+				Statement statement = connection.createStatement();
+				ResultSet resultSet = statement.executeQuery("SELECT 1")) {
 
-            assertTrue(resultSet.next());
-            assertEquals(1, resultSet.getInt(1));
-        }
-    }
-    @Test
-    void testConnection_shouldReturnFalseWhenConnectionFails() {
-        DatabaseManagerSQLite manager = new DatabaseManagerSQLite(":memory:") {
-            @Override
-            public Connection getConnection() throws SQLException {
-                throw new SQLException("Database connection failed");
-            }
-        };
+			assertTrue(resultSet.next());
+			assertEquals(1, resultSet.getInt(1));
+		}
+	}
+	@Test
+	void testConnection_shouldReturnFalseWhenConnectionFails() {
+		DatabaseManagerSQLite manager = new DatabaseManagerSQLite(":memory:") {
+			@Override
+			public Connection getConnection() throws SQLException {
+				throw new SQLException("Database connection failed");
+			}
+		};
 
-        assertFalse(manager.testConnection());
-    }
+		assertFalse(manager.testConnection());
+	}
 }


### PR DESCRIPTION
## Summary

Adds automated tests for the core database managers as part of issue #40.

## Changes

- Added SQLite database manager tests using an in-memory SQLite database.
- Added Oracle database manager tests using Mockito mocks.
- Added factory tests for Oracle, SQLite, and fallback configurations.
- Added SQL failure-path tests.
- Added resource cleanup verification for Oracle database connections.

## Verification

- Ran `mvn spotless:apply`
- Ran `mvn clean install`
- Build and all tests pass successfully

## AI Assistance
AI tools were used to assist with understanding the existing codebase, designing test cases, and generating parts of the test implementation. I reviewed and verified the submitted changes and understand the implementation well enough to explain, modify, debug, and maintain it.

Closes #40
