### PR TITLE
refactor: implement `getConfigKey` for `IDatabaseManager`, replace ra…

### DIFF
--- a/src/main/java/com/GMRP/Main.java
+++ b/src/main/java/com/GMRP/Main.java
@@ -3,14 +3,11 @@
 package com.GMRP;
 
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.*;
 
 import com.GMRP.core.databaseManager.DatabaseManagerFactory;
 import com.GMRP.core.databaseManager.IDatabaseManager;
+import com.GMRP.core.databaseManager.exception.DatabaseManagerException;
 import com.GMRP.core.gitManager.GitManager;
 import com.GMRP.features.ILoopController;
 import com.GMRP.features.ISlashCommandController;
@@ -32,9 +29,8 @@ public class Main {
 		// Initialize Models
 		// GMRP Repo
 		BotConfig.init();
-		try {
+		try (IDatabaseManager databaseManager = DatabaseManagerFactory.create();) {
 			GitManager repositoryManager = new GitManager(".");
-			IDatabaseManager databaseManager = DatabaseManagerFactory.create();
 			databaseManager.testConnection();
 
 			// Slash Commands
@@ -77,24 +73,17 @@ public class Main {
 
 			// Guild to save the commands to
 			Guild guild;
-			try (Connection connection = databaseManager.getConnection();
-					PreparedStatement preparedStatement = connection
-							.prepareStatement("SELECT CONFIG_VALUE FROM CONFIG WHERE CONFIG_KEY = ?")) {
-				preparedStatement.setString(1, "SERVER");
-				try (ResultSet resultSet = preparedStatement.executeQuery()) {
-					if (!resultSet.next())
-						throw new RuntimeException("Guild ID not found in the database.");
-					guild = jda.getGuildById(resultSet.getString(1));
-				}
+			try {
+				guild = jda.getGuildById(databaseManager.getConfigKey("SERVER"));
+			} catch (DatabaseManagerException e) {
+				throw new RuntimeException("Guild ID not found in the database.");
 			}
 
 			// Push the list of command setups to the guild
 			guild.updateCommands().addCommands(commandSetups).queue();
 			Runtime.getRuntime().addShutdownHook(new Thread(databaseManager::close));
-		} catch (IOException | InterruptedException e) {
+		} catch (IOException | InterruptedException | DatabaseManagerException e) {
 			e.printStackTrace();
-		} catch (SQLException e) {
-			throw new RuntimeException(e);
 		}
 	}
 }

--- a/src/main/java/com/GMRP/core/databaseManager/DatabaseManagerFactory.java
+++ b/src/main/java/com/GMRP/core/databaseManager/DatabaseManagerFactory.java
@@ -2,16 +2,15 @@
 
 package com.GMRP.core.databaseManager;
 
-import java.sql.SQLException;
-
 import com.GMRP.BotConfig;
+import com.GMRP.core.databaseManager.exception.DatabaseManagerException;
 
 public final class DatabaseManagerFactory {
 
 	private DatabaseManagerFactory() {
 	}
 
-	public static IDatabaseManager create() throws SQLException {
+	public static IDatabaseManager create() throws DatabaseManagerException {
 		String dbType = BotConfig.getInstance().getDbType().toLowerCase();
 		if ("oracle".equals(dbType)) {
 			return new DatabaseManagerOracle();

--- a/src/main/java/com/GMRP/core/databaseManager/DatabaseManagerOracle.java
+++ b/src/main/java/com/GMRP/core/databaseManager/DatabaseManagerOracle.java
@@ -2,13 +2,11 @@
 
 package com.GMRP.core.databaseManager;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 
 import com.GMRP.BotConfig;
 
+import com.GMRP.core.databaseManager.exception.DatabaseManagerException;
 import oracle.ucp.admin.UniversalConnectionPoolManager;
 import oracle.ucp.admin.UniversalConnectionPoolManagerImpl;
 import oracle.ucp.jdbc.PoolDataSource;
@@ -21,26 +19,33 @@ public class DatabaseManagerOracle implements IDatabaseManager {
 
 	private final PoolDataSource oraclePool; // null when using SQLite
 
-	public DatabaseManagerOracle() throws SQLException {
-		this.oraclePool = createOraclePool();
+	public DatabaseManagerOracle() throws DatabaseManagerException {
+		try {
+			this.oraclePool = createOraclePool();
+		} catch (SQLException e) {
+			throw new DatabaseManagerException("Failed to create Oracle connection pool", e);
+		}
 	}
 
-	@Override
-	public Connection getConnection() throws SQLException {
-		return oraclePool.getConnection();
+	private Connection getConnection() throws DatabaseManagerException {
+		try {
+			return oraclePool.getConnection();
+		} catch (SQLException e) {
+			throw new DatabaseManagerException("Failed to connect to Oracle database", e);
+		}
 	}
 
 	@Override
 	public boolean testConnection() {
 		try (Connection conn = getConnection();
-				Statement stmt = conn.createStatement();
-				ResultSet rs = stmt.executeQuery("SELECT 1 FROM DUAL")) {
+				Statement statement = conn.createStatement();
+				ResultSet resultSet = statement.executeQuery("SELECT 1 FROM DUAL")) {
 
-			if (rs.next()) {
-				System.out.println("Database connection OK (Oracle). Test result: " + rs.getInt(1));
+			if (resultSet.next()) {
+				System.out.println("Database connection OK (Oracle). Test result: " + resultSet.getInt(1));
 				return true;
 			}
-		} catch (SQLException e) {
+		} catch (DatabaseManagerException | SQLException e) {
 			System.err.println("Database connection FAILED (Oracle): " + e.getMessage());
 		}
 		return false;
@@ -57,6 +62,22 @@ public class DatabaseManagerOracle implements IDatabaseManager {
 			}
 		} catch (Exception e) {
 			System.err.println("Error while destroying Oracle connection pool: " + e.getMessage());
+		}
+	}
+
+	@Override
+	public String getConfigKey(String key) throws DatabaseManagerException {
+		try (Connection connection = this.getConnection();
+				PreparedStatement preparedStatement = connection
+						.prepareStatement("SELECT CONFIG_VALUE FROM CONFIG WHERE CONFIG_KEY = ?")) {
+			preparedStatement.setString(1, key);
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (!resultSet.next())
+					throw new DatabaseManagerException(key + " not found in the database.");
+				return resultSet.getString(1);
+			}
+		} catch (DatabaseManagerException | SQLException e) {
+			throw new DatabaseManagerException("Failed to get config value from database", e);
 		}
 	}
 

--- a/src/main/java/com/GMRP/core/databaseManager/DatabaseManagerSQLite.java
+++ b/src/main/java/com/GMRP/core/databaseManager/DatabaseManagerSQLite.java
@@ -2,12 +2,10 @@
 
 package com.GMRP.core.databaseManager;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 
 import com.GMRP.BotConfig;
+import com.GMRP.core.databaseManager.exception.DatabaseManagerException;
 
 /**
  * Database access point supporting SQLite.
@@ -24,10 +22,15 @@ public class DatabaseManagerSQLite implements IDatabaseManager {
 		this.sqliteUrl = "jdbc:sqlite:" + sqlitePath;
 	}
 
-	public Connection getConnection() throws SQLException {
-		return java.sql.DriverManager.getConnection(sqliteUrl);
+	private Connection getConnection() throws DatabaseManagerException {
+		try {
+			return java.sql.DriverManager.getConnection(sqliteUrl);
+		} catch (SQLException e) {
+			throw new DatabaseManagerException("Failed to connect to SQLite database", e);
+		}
 	}
 
+	@Override
 	public boolean testConnection() {
 		try (Connection conn = getConnection();
 				Statement stmt = conn.createStatement();
@@ -37,7 +40,7 @@ public class DatabaseManagerSQLite implements IDatabaseManager {
 				System.out.println("Database connection OK (SQLite). Test result: " + rs.getInt(1));
 				return true;
 			}
-		} catch (SQLException e) {
+		} catch (DatabaseManagerException | SQLException e) {
 			System.err.println("Database connection FAILED (SQLite): " + e.getMessage());
 		}
 		return false;
@@ -46,5 +49,21 @@ public class DatabaseManagerSQLite implements IDatabaseManager {
 	@Override
 	public void close() {
 		// SQLite has no pool to destroy
+	}
+
+	@Override
+	public String getConfigKey(String key) throws DatabaseManagerException {
+		try (Connection connection = this.getConnection();
+				PreparedStatement preparedStatement = connection
+						.prepareStatement("SELECT CONFIG_VALUE FROM CONFIG WHERE CONFIG_KEY = ?")) {
+			preparedStatement.setString(1, key);
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (!resultSet.next())
+					throw new DatabaseManagerException(key + " not found in the database.");
+				return resultSet.getString(1);
+			}
+		} catch (DatabaseManagerException | SQLException e) {
+			throw new DatabaseManagerException("Failed to get config value from database", e);
+		}
 	}
 }

--- a/src/main/java/com/GMRP/core/databaseManager/IDatabaseManager.java
+++ b/src/main/java/com/GMRP/core/databaseManager/IDatabaseManager.java
@@ -2,19 +2,13 @@
 
 package com.GMRP.core.databaseManager;
 
-import java.sql.Connection;
-import java.sql.SQLException;
+import com.GMRP.core.databaseManager.exception.DatabaseManagerException;
 
 /**
  * Database access point. Implementations exist for Oracle (UCP) and SQLite.
  * Designed for constructor-based dependency injection.
  */
 public interface IDatabaseManager extends AutoCloseable {
-
-	/**
-	 * Returns a Connection. Always close it (preferably with try-with-resources).
-	 */
-	Connection getConnection() throws SQLException;
 
 	/**
 	 * Simple connectivity check. Useful at startup or in tests.
@@ -26,4 +20,9 @@ public interface IDatabaseManager extends AutoCloseable {
 	 */
 	@Override
 	void close();
+
+	/**
+	 * Get the value of a specific configuration key
+	 */
+	String getConfigKey(String key) throws DatabaseManagerException;
 }

--- a/src/main/java/com/GMRP/core/databaseManager/exception/DatabaseManagerException.java
+++ b/src/main/java/com/GMRP/core/databaseManager/exception/DatabaseManagerException.java
@@ -1,0 +1,14 @@
+package com.GMRP.core.databaseManager.exception;
+
+/**
+ * Root exception for all database manager-related errors.
+ */
+public class DatabaseManagerException extends Exception {
+	public DatabaseManagerException(String message) {
+		super(message);
+	}
+
+	public DatabaseManagerException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/main/java/com/GMRP/features/aboutCommand/AboutCommandController.java
+++ b/src/main/java/com/GMRP/features/aboutCommand/AboutCommandController.java
@@ -3,6 +3,7 @@
 package com.GMRP.features.aboutCommand;
 
 import com.GMRP.core.databaseManager.IDatabaseManager;
+import com.GMRP.core.databaseManager.exception.DatabaseManagerException;
 import com.GMRP.core.gitManager.GitManager;
 import com.GMRP.features.ISlashCommandController;
 
@@ -11,11 +12,6 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 
 public class AboutCommandController extends ListenerAdapter implements ISlashCommandController {
 	private final AboutEmbedView view;
@@ -42,24 +38,19 @@ public class AboutCommandController extends ListenerAdapter implements ISlashCom
 	public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		if (!event.getFullCommandName().equalsIgnoreCase("about"))
 			return;
-		try (Connection connection = this.databaseManager.getConnection();
-				PreparedStatement preparedStatement = connection
-						.prepareStatement("SELECT CONFIG_VALUE FROM CONFIG WHERE CONFIG_KEY = ?")) {
-			preparedStatement.setString(1, "OWNER");
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				if (!resultSet.next()) {
-					event.reply("Owner ID not found in the database.").setEphemeral(true).queue();
-					return;
-				}
-				String ownerId = resultSet.getString(1);
-				String ownerMention = "<@" + ownerId + ">";
-				String currentBranch = gitManager.getCurrentBranch();
-				String version = VersionReader.getVersion();
-				MessageEmbed aboutEmbed = view.formatAboutEmbed(ownerMention, currentBranch, version);
-				event.replyEmbeds(aboutEmbed).queue();
-			}
-		} catch (SQLException e) {
-			event.reply("An error occurred while retrieving the owner ID.").setEphemeral(true).queue();
+
+		String ownerId;
+
+		try {
+			ownerId = databaseManager.getConfigKey("OWNER");
+		} catch (DatabaseManagerException e) {
+			event.reply("Owner ID not found in the database.").setEphemeral(true).queue();
+			return;
 		}
+		String ownerMention = "<@" + ownerId + ">";
+		String currentBranch = gitManager.getCurrentBranch();
+		String version = VersionReader.getVersion();
+		MessageEmbed aboutEmbed = view.formatAboutEmbed(ownerMention, currentBranch, version);
+		event.replyEmbeds(aboutEmbed).queue();
 	}
 }

--- a/src/main/java/com/GMRP/features/moderation/botBait/BotBaitEventController.java
+++ b/src/main/java/com/GMRP/features/moderation/botBait/BotBaitEventController.java
@@ -3,6 +3,7 @@
 package com.GMRP.features.moderation.botBait;
 
 import com.GMRP.core.databaseManager.IDatabaseManager;
+import com.GMRP.core.databaseManager.exception.DatabaseManagerException;
 import com.GMRP.features.ILoopController;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -10,10 +11,6 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.Permission;
 import org.jetbrains.annotations.NotNull;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.concurrent.TimeUnit;
 
 public class BotBaitEventController extends ListenerAdapter implements ILoopController {
@@ -32,20 +29,16 @@ public class BotBaitEventController extends ListenerAdapter implements ILoopCont
 			return;
 
 		// Only applies to the Bot Bait channel.
-		try (Connection connection = databaseManager.getConnection();
-				PreparedStatement preparedStatement = connection
-						.prepareStatement("SELECT CONFIG_VALUE FROM CONFIG WHERE CONFIG_KEY = ?")) {
-			preparedStatement.setString(1, "BAIT");
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				// there is no bait channel
-				if (!resultSet.next())
-					return;
-				if (!event.getChannel().getId().equals(resultSet.getString(1)))
-					return;
-			}
-		} catch (SQLException e) {
+		String botBaitChannelId;
+		try {
+			botBaitChannelId = databaseManager.getConfigKey("BAIT");
+		} catch (DatabaseManagerException e) {
 			e.printStackTrace();
+			return;
 		}
+
+		if (!event.getChannel().getId().equals(botBaitChannelId))
+			return;
 
 		// Don't ban actual bots nor try to ban a webhook.
 		if (event.getAuthor().isBot() || event.isWebhookMessage())

--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerFactoryTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerFactoryTest.java
@@ -1,17 +1,22 @@
 /* SPDX-License-Identifier: AGPL-3.0-or-later */
+
 package com.GMRP.core.databaseManager;
+
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+
+import com.GMRP.core.databaseManager.exception.DatabaseManagerException;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import static org.mockito.Mockito.mockConstruction;
 import com.GMRP.BotConfig;
+
 public class DatabaseManagerFactoryTest {
 	@Test
-	void create_shouldReturnSQLiteManagerForSQLiteConfig() throws Exception {
+	void create_shouldReturnSQLiteManagerForSQLiteConfig() throws DatabaseManagerException {
 		BotConfig config = mock(BotConfig.class);
 
 		when(config.getDbType()).thenReturn("sqlite");
@@ -27,7 +32,7 @@ public class DatabaseManagerFactoryTest {
 		}
 	}
 	@Test
-	void create_shouldReturnSQLiteManagerForUnknownDatabaseType() throws Exception {
+	void create_shouldReturnSQLiteManagerForUnknownDatabaseType() throws DatabaseManagerException {
 		BotConfig config = mock(BotConfig.class);
 
 		when(config.getDbType()).thenReturn("unknown");
@@ -43,7 +48,7 @@ public class DatabaseManagerFactoryTest {
 		}
 	}
 	@Test
-	void create_shouldReturnOracleManagerForOracleConfig() throws Exception {
+	void create_shouldReturnOracleManagerForOracleConfig() throws DatabaseManagerException {
 		BotConfig config = mock(BotConfig.class);
 
 		when(config.getDbType()).thenReturn("oracle");

--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerOracleTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerOracleTest.java
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: AGPL-3.0-or-later */
+
 package com.GMRP.core.databaseManager;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -13,35 +15,12 @@ import oracle.ucp.jdbc.PoolDataSourceFactory;
 import static org.mockito.Mockito.verify;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.PreparedStatement;
 import java.sql.Statement;
 
+import com.GMRP.core.databaseManager.exception.DatabaseManagerException;
+
 public class DatabaseManagerOracleTest {
-	@Test
-	void getConnection_shouldReturnConnectionFromPool() throws Exception {
-		PoolDataSource pool = mock(PoolDataSource.class);
-		Connection connection = mock(Connection.class);
-		BotConfig config = mock(BotConfig.class);
-
-		when(config.getDbConnectString()).thenReturn("test");
-		when(config.getDbUser()).thenReturn("user");
-		when(config.getDbPassword()).thenReturn("password");
-		when(pool.getConnection()).thenReturn(connection);
-
-		try (MockedStatic<PoolDataSourceFactory> poolFactory = mockStatic(PoolDataSourceFactory.class);
-				MockedStatic<BotConfig> botConfig = mockStatic(BotConfig.class)) {
-
-			poolFactory.when(PoolDataSourceFactory::getPoolDataSource)
-					.thenReturn(pool);
-
-			botConfig.when(BotConfig::getInstance)
-					.thenReturn(config);
-
-			DatabaseManagerOracle manager = new DatabaseManagerOracle();
-
-			assertSame(connection, manager.getConnection());
-		}
-	}
-
 	@Test
 	void testConnection_shouldReturnTrueWhenQuerySucceeds() throws Exception {
 		PoolDataSource pool = mock(PoolDataSource.class);
@@ -161,6 +140,62 @@ public class DatabaseManagerOracleTest {
 			verify(resultSet).close();
 			verify(statement).close();
 			verify(connection).close();
+		}
+	}
+
+	@Test
+	void getConfigKey_shouldReturnConfiguredValue() throws Exception {
+		PoolDataSource pool = mock(PoolDataSource.class);
+		Connection connection = mock(Connection.class);
+		PreparedStatement preparedStatement = mock(PreparedStatement.class);
+		ResultSet resultSet = mock(ResultSet.class);
+		BotConfig config = mock(BotConfig.class);
+
+		when(config.getDbConnectString()).thenReturn("test");
+		when(config.getDbUser()).thenReturn("user");
+		when(config.getDbPassword()).thenReturn("password");
+		when(pool.getConnection()).thenReturn(connection);
+		when(connection.prepareStatement("SELECT CONFIG_VALUE FROM CONFIG WHERE CONFIG_KEY = ?"))
+				.thenReturn(preparedStatement);
+		when(preparedStatement.executeQuery()).thenReturn(resultSet);
+		when(resultSet.next()).thenReturn(true);
+		when(resultSet.getString(1)).thenReturn("12345");
+
+		try (MockedStatic<PoolDataSourceFactory> poolFactory = mockStatic(PoolDataSourceFactory.class);
+				MockedStatic<BotConfig> botConfig = mockStatic(BotConfig.class)) {
+			poolFactory.when(PoolDataSourceFactory::getPoolDataSource).thenReturn(pool);
+			botConfig.when(BotConfig::getInstance).thenReturn(config);
+
+			DatabaseManagerOracle manager = new DatabaseManagerOracle();
+
+			assertEquals("12345", manager.getConfigKey("OWNER"));
+			verify(preparedStatement).setString(1, "OWNER");
+		}
+	}
+
+	@Test
+	void getConfigKey_shouldWrapSqlException() throws Exception {
+		PoolDataSource pool = mock(PoolDataSource.class);
+		Connection connection = mock(Connection.class);
+		BotConfig config = mock(BotConfig.class);
+
+		when(config.getDbConnectString()).thenReturn("test");
+		when(config.getDbUser()).thenReturn("user");
+		when(config.getDbPassword()).thenReturn("password");
+		when(pool.getConnection()).thenReturn(connection);
+		when(connection.prepareStatement("SELECT CONFIG_VALUE FROM CONFIG WHERE CONFIG_KEY = ?"))
+				.thenThrow(new SQLException("Database query failed"));
+
+		try (MockedStatic<PoolDataSourceFactory> poolFactory = mockStatic(PoolDataSourceFactory.class);
+				MockedStatic<BotConfig> botConfig = mockStatic(BotConfig.class)) {
+			poolFactory.when(PoolDataSourceFactory::getPoolDataSource).thenReturn(pool);
+			botConfig.when(BotConfig::getInstance).thenReturn(config);
+
+			DatabaseManagerOracle manager = new DatabaseManagerOracle();
+
+			DatabaseManagerException exception = assertThrows(DatabaseManagerException.class,
+					() -> manager.getConfigKey("OWNER"));
+			assertEquals("Failed to get config value from database", exception.getMessage());
 		}
 	}
 }

--- a/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerSQLiteTest.java
+++ b/src/test/java/com/GMRP/core/databaseManager/DatabaseManagerSQLiteTest.java
@@ -1,22 +1,24 @@
 /* SPDX-License-Identifier: AGPL-3.0-or-later */
+
 package com.GMRP.core.databaseManager;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
 import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.ResultSet;
-import java.sql.Statement;
+import java.sql.DriverManager;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.GMRP.core.databaseManager.exception.DatabaseManagerException;
 
 public class DatabaseManagerSQLiteTest {
-	@Test
-	void getConnection_shouldReturnValidConnection() throws SQLException {
-		DatabaseManagerSQLite manager = new DatabaseManagerSQLite(":memory:");
+	@TempDir
+	Path temporaryDirectory;
 
-		try (Connection connection = manager.getConnection()) {
-			assertNotNull(connection);
-			assertFalse(connection.isClosed());
-		}
-	}
 	@Test
 	void testConnection_shouldReturnTrueForValidDatabase() {
 		DatabaseManagerSQLite manager = new DatabaseManagerSQLite(":memory:");
@@ -24,26 +26,31 @@ public class DatabaseManagerSQLiteTest {
 		assertTrue(manager.testConnection());
 	}
 	@Test
-	void getConnection_shouldAllowSqlExecution() throws SQLException {
-		DatabaseManagerSQLite manager = new DatabaseManagerSQLite(":memory:");
-
-		try (Connection connection = manager.getConnection();
-				Statement statement = connection.createStatement();
-				ResultSet resultSet = statement.executeQuery("SELECT 1")) {
-
-			assertTrue(resultSet.next());
-			assertEquals(1, resultSet.getInt(1));
+	void getConfigKey_shouldReturnConfiguredValue() throws Exception {
+		Path databasePath = temporaryDirectory.resolve("config.db");
+		try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
+				var statement = connection.createStatement()) {
+			statement.executeUpdate("CREATE TABLE CONFIG (CONFIG_KEY TEXT, CONFIG_VALUE TEXT)");
+			statement.executeUpdate("INSERT INTO CONFIG VALUES ('OWNER', '12345')");
 		}
-	}
-	@Test
-	void testConnection_shouldReturnFalseWhenConnectionFails() {
-		DatabaseManagerSQLite manager = new DatabaseManagerSQLite(":memory:") {
-			@Override
-			public Connection getConnection() throws SQLException {
-				throw new SQLException("Database connection failed");
-			}
-		};
 
-		assertFalse(manager.testConnection());
+		DatabaseManagerSQLite manager = new DatabaseManagerSQLite(databasePath.toString());
+
+		assertEquals("12345", manager.getConfigKey("OWNER"));
+	}
+
+	@Test
+	void getConfigKey_shouldThrowDatabaseManagerExceptionWhenKeyIsMissing() throws Exception {
+		Path databasePath = temporaryDirectory.resolve("config.db");
+		try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
+				var statement = connection.createStatement()) {
+			statement.executeUpdate("CREATE TABLE CONFIG (CONFIG_KEY TEXT, CONFIG_VALUE TEXT)");
+		}
+
+		DatabaseManagerSQLite manager = new DatabaseManagerSQLite(databasePath.toString());
+
+		DatabaseManagerException exception = assertThrows(DatabaseManagerException.class,
+				() -> manager.getConfigKey("MISSING"));
+		assertEquals("Failed to get config value from database", exception.getMessage());
 	}
 }


### PR DESCRIPTION
…w queries with abstraction, and improve error handling

> [!WARNING]
> **STOP:** All Pull Requests MUST target the `develop` branch. Any PR targeting `main` will be closed immediately.

## Description
Refactor database access to encapsulate config lookups behind the `IDatabaseManager` abstraction.

- Add `getConfigKey(String key)` to `IDatabaseManager` and implement it in both `DatabaseManagerSQLite` and `DatabaseManagerOracle`.
- Introduce `DatabaseManagerException` for cleaner, consistent error handling when a config key is missing or a DB operation fails.
- Replace raw SQL (`SELECT CONFIG_VALUE FROM CONFIG WHERE CONFIG_KEY = ?`) in `Main`, `AboutCommandController`, and `BotBaitEventController` with calls to `getConfigKey(...)`.
- Improve resource management in `Main` by using try-with-resources on the database manager.
- Update unit tests to cover the new method (success path and missing-key exception path).

This removes duplicated query logic from feature code, improves encapsulation of the SQL layer, and makes future changes to config storage easier.

## Linked Issue
Fixes #38

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Code refactoring or cleanup
- [ ] Documentation update

## Code Quality & Testing Checklist
- [x] I have targeted the `develop` branch.
- [x] I have tested my changes locally. <!-- using a dummy SQLite database (NOT the production database). -->
- [x] I have formatted my code by running `mvn spotless:apply`.
- [x] I have verified my logic and tests pass by running `mvn clean install` without any Checkstyle or JUnit errors.
- [x] My commits follow standard naming conventions and provide clear history.

## Additional Notes (Optional)